### PR TITLE
Extend import statement to support Python 3

### DIFF
--- a/dash_renderer/__init__.py
+++ b/dash_renderer/__init__.py
@@ -7,7 +7,7 @@
 # command in the dash_html_components package which printed out:
 # `dash_html_components.__init__: module references __file__`
 # TODO - Understand this better
-from version import __version__
+from .version import __version__
 __file__
 
 # Dash renderer's dependencies get loaded in a special order by the server:


### PR DESCRIPTION
After configuring `tox` for [dash2](https://github.com/plotly/dash2), the build is failing on **Python 3** environment.

```
File "/home/ubuntu/dash2/.tox/py34/lib/python3.4/site-packages/dash_renderer/__init__.py", line 10, in <module>
    from version import __version__
ImportError: No module named 'version'
```

Having a relative import will fix this.

```pyhon
from .version import __version__
```

I request you to bump the version and upload on PyPI after you find it suitable to merge, doing so will fix the particular error in Circle CI build.