### PR TITLE
make library available in `window`

### DIFF
--- a/config/partials/outputProd.js
+++ b/config/partials/outputProd.js
@@ -11,6 +11,7 @@ module.exports = function (config) {
         output: {
             path: BUILD,
             publicPath: '/dash_renderer/',
+            library: 'dash_renderer',
             // TODO: Bundle filename should be hashed (#10)
             filename: '[name].js'
         }


### PR DESCRIPTION
so that we can check its availability to do fallback CDN handling