### PR TITLE
Added a CSS class to error messages.

### DIFF
--- a/src/APIController.react.js
+++ b/src/APIController.react.js
@@ -83,7 +83,7 @@ class UnconnectedContainer extends Component {
         if (layoutRequest.status &&
             !contains(layoutRequest.status, [200, 'loading'])
         ) {
-            return (<div>{'Error loading layout'}</div>);
+            return (<div className="_dash-error">{'Error loading layout'}</div>);
         }
 
 
@@ -91,7 +91,7 @@ class UnconnectedContainer extends Component {
             dependenciesRequest.status &&
             !contains(dependenciesRequest.status, [200, 'loading'])
         ) {
-            return (<div>{'Error loading dependencies'}</div>);
+            return (<div className="_dash-error">{'Error loading dependencies'}</div>);
         }
 
 


### PR DESCRIPTION
Added a CSS class to error messages output by dash on load to allow them to be styled.

A workaround for this is to use a (fragile) selector path to match the element, e.g.

```css
#react-entry-point > div > div:nth-child(2):not([id]):not([class])
```