### PR TITLE
Only one percy build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,16 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.6-stretch-node-browsers
+    environment:
+      PERCY_ENABLE: 0
 
   "python-3.7":
     <<: *test-template
     docker:
       - image: circleci/python:3.7-stretch-node-browsers
+    environment:
+      PERCY_ENABLE: 0
+
 
 workflows:
   version: 2


### PR DESCRIPTION
Only run percy in python 2.7, plotly/dash#370.