### PR TITLE
Add test for hot reload

### DIFF
--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -49,15 +49,17 @@ class IntegrationTests(unittest.TestCase):
         s.server_process.terminate()
         time.sleep(2)
 
-    def startServer(s, dash):
+    def startServer(s, dash, **kwargs):
         def run():
             dash.scripts.config.serve_locally = True
-            dash.run_server(
+            kws = dict(
                 port=8050,
                 debug=False,
                 processes=4,
                 threaded=False
             )
+            kws.update(kwargs)
+            dash.run_server(**kws)
 
         # Run on a separate process so that it doesn't block
         s.server_process = multiprocessing.Process(target=run)

--- a/tests/test_assets/hot_reload.css
+++ b/tests/test_assets/hot_reload.css
@@ -1,0 +1,3 @@
+#hot-reload-content {
+    background-color: blue;
+}


### PR DESCRIPTION
- added `wait_for_style_to_equal`
- added `run_server` kwargs to `startServer`.
- added test_hot_reload: change the background color of an asset CSS after starting the server with hot reload enabled and wait for the style to change.

Closes #111 