### PR TITLE
[WIP] Renderer regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Install dependencies (dash)
           command: |
               git clone git@github.com:plotly/dash.git
-              git clone git@github.com:plotly/dash-core-components.git
+              git clone -b renderer-regression git@github.com:plotly/dash-core-components.git
               git clone git@github.com:plotly/dash-html-components.git
               git clone git@github.com:plotly/dash-table.git
               . venv/bin/activate

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -32,6 +32,16 @@ const createContainer = component => isSimpleComponent(component) ?
     />);
 
 class TreeContainer extends Component {
+    getChildren(components) {
+        if (!components) {
+            return null;
+        }
+
+        return Array.isArray(components) ?
+            map(createContainer, components) :
+            createContainer(components);
+    }
+
     getLoadingState() {
         const {
             _dashprivate_layout: layout,
@@ -101,16 +111,6 @@ class TreeContainer extends Component {
         }
 
         return ids;
-    }
-
-    getChildren(components) {
-        if (!components) {
-            return null;
-        }
-
-        return Array.isArray(components) ?
-            map(createContainer, components) :
-            createContainer(components);
     }
 
     getComponent(_dashprivate_layout, children, loading_state, setProps) {

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -172,7 +172,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
 }
 
 function getLoadingState(layout, requestQueue) {
-    const ids = isDeepStateElement(layout) ?
+    const ids = isLoadingComponent(layout) ?
         getNestedIds(layout) :
         (layout && layout.props.id ?
             [layout.props.id] :
@@ -222,7 +222,7 @@ function getNestedIds(layout) {
 
         if (children) {
             const filteredChildren = filter(
-                child => !isSimpleComponent(child) && !isDeepStateElement(child),
+                child => !isSimpleComponent(child) && !isLoadingComponent(child),
                 Array.isArray(children) ? children : [children]
             );
 
@@ -233,7 +233,7 @@ function getNestedIds(layout) {
     return ids;
 }
 
-function isDeepStateElement(layout) {
+function isLoadingComponent(layout) {
     return Registry.resolve(layout.type, layout.namespace)._dashprivate_isLoadingComponent;
 }
 

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -222,7 +222,7 @@ function getNestedIds(layout) {
 
         if (children) {
             const filteredChildren = filter(
-                child => !isSimpleComponent(child) && !Registry.resolve(child.type, child.namespace)._dashprivate_deepstate,
+                child => !isSimpleComponent(child) && !isDeepStateElement(child),
                 Array.isArray(children) ? children : [children]
             );
 
@@ -234,7 +234,7 @@ function getNestedIds(layout) {
 }
 
 function isDeepStateElement(layout) {
-    return Registry.resolve(layout.type, layout.namespace)._dashprivate_deepstate;
+    return Registry.resolve(layout.type, layout.namespace)._dashprivate_isLoadingComponent;
 }
 
 export const AugmentedTreeContainer = connect(mapStateToProps, mapDispatchToProps, mergeProps)(TreeContainer);

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -176,7 +176,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
 
 function getLoadingState(layout, requestQueue) {
     const ids = isDeepStateElement(layout) ?
-        getNestedIds() :
+        getNestedIds(layout) :
         (layout && layout.props.id ?
             [layout.props.id] :
             []);

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -127,7 +127,7 @@ class TreeContainer extends Component {
         const {
             _dashprivate_dispatch,
             _dashprivate_layout,
-            _dashprivate_requestQueue
+            _dashprivate_loadingState
         } = this.props;
 
         const layoutProps = this.getLayoutProps();
@@ -135,10 +135,7 @@ class TreeContainer extends Component {
         const children = this.getChildren(layoutProps.children);
         const setProps = this.getSetProps(_dashprivate_dispatch);
 
-        const loadingState = getLoadingState(_dashprivate_layout, _dashprivate_requestQueue);
-
-        return this.getComponent(
-            _dashprivate_layout, children, loadingState, setProps);
+        return this.getComponent(_dashprivate_layout, children, _dashprivate_loadingState, setProps);
     }
 }
 

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -42,6 +42,39 @@ class TreeContainer extends Component {
             createContainer(components);
     }
 
+    getComponent(_dashprivate_layout, children, loading_state, setProps) {
+        if (isEmpty(_dashprivate_layout)) {
+            return null;
+        }
+
+        if (isSimpleComponent(_dashprivate_layout)) {
+            return _dashprivate_layout;
+        }
+
+        if (!_dashprivate_layout.type) {
+            /* eslint-disable no-console */
+            console.error(type(_dashprivate_layout), _dashprivate_layout);
+            /* eslint-enable no-console */
+            throw new Error('component.type is undefined');
+        }
+        if (!_dashprivate_layout.namespace) {
+            /* eslint-disable no-console */
+            console.error(type(_dashprivate_layout), _dashprivate_layout);
+            /* eslint-enable no-console */
+            throw new Error('component.namespace is undefined');
+        }
+        const element = Registry.resolve(_dashprivate_layout.type, _dashprivate_layout.namespace);
+
+        return React.createElement(
+            element,
+            mergeAll([
+                omit(['children'], _dashprivate_layout.props),
+                { loading_state, setProps }
+            ]),
+            ...(Array.isArray(children) ? children : [children])
+        );
+    }
+
     getLoadingState() {
         const {
             _dashprivate_layout: layout,
@@ -111,39 +144,6 @@ class TreeContainer extends Component {
         }
 
         return ids;
-    }
-
-    getComponent(_dashprivate_layout, children, loading_state, setProps) {
-        if (isEmpty(_dashprivate_layout)) {
-            return null;
-        }
-
-        if (isSimpleComponent(_dashprivate_layout)) {
-            return _dashprivate_layout;
-        }
-
-        if (!_dashprivate_layout.type) {
-            /* eslint-disable no-console */
-            console.error(type(_dashprivate_layout), _dashprivate_layout);
-            /* eslint-enable no-console */
-            throw new Error('component.type is undefined');
-        }
-        if (!_dashprivate_layout.namespace) {
-            /* eslint-disable no-console */
-            console.error(type(_dashprivate_layout), _dashprivate_layout);
-            /* eslint-enable no-console */
-            throw new Error('component.namespace is undefined');
-        }
-        const element = Registry.resolve(_dashprivate_layout.type, _dashprivate_layout.namespace);
-
-        return React.createElement(
-            element,
-            mergeAll([
-                omit(['children'], _dashprivate_layout.props),
-                { loading_state, setProps }
-            ]),
-            ...(Array.isArray(children) ? children : [children])
-        );
     }
 
     getSetProps() {


### PR DESCRIPTION
To be reviewed alongside https://github.com/plotly/dash-core-components/pull/496.

- [ ] Changelog for previous optimization

Related CI runs for all dash-core projects running against the `regression` branches of dcc and renderer:
https://circleci.com/gh/plotly/dash/3447
https://circleci.com/gh/plotly/dash/3446
https://circleci.com/gh/plotly/dash/3435
https://circleci.com/gh/plotly/dash-core-components/3963
https://circleci.com/gh/plotly/dash-core-components/3962
https://circleci.com/gh/plotly/dash-core-components/3961
https://circleci.com/gh/plotly/dash-html-components/889
https://circleci.com/gh/plotly/dash-html-components/888
https://circleci.com/gh/plotly/dash-html-components/887
https://circleci.com/gh/plotly/dash-table/6283
https://circleci.com/gh/plotly/dash-table/6282
https://circleci.com/gh/plotly/dash-table/6281
https://circleci.com/gh/plotly/dash-table/6280
https://circleci.com/gh/plotly/dash-table/6279
https://circleci.com/gh/plotly/dash-table/6278

This fixes the regression in Loading Component caused by the renderer optimization. The LC was using the nested children tree structure to determine if it was loading or not. Since the tree containers do not contain the child anymore but instead generate them at render, the LC is only capable of reacting to direct children having loading_state=true.

To resolve the loading state of the LC, two information are now required (1) the layout -- accessible through the children and (2) the request queue. A naive implementation adding the request queue to all tree containers and re-rendering on both request queue and layout changes triggers an excessive amount of re-renders, losing a significant portion of the performance gains made through the previous rework.

To remedy this, the renderer now checks for a flag defined on the component `_dashprivate_deepstate` that tells it to determine the state of the component by checking the state of all of its children, pruning when reaching another component with _dashprivate_deepstate set to true. This allows the renderer to determine the loading_state of all components without having them figure it out for themselves -- if the component flag was made "official" this would allow for a community custom loading component to be made. There is no performance impact to this solution.