### PR TITLE
Issue148 - `0` children regression in dash==0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fix regression for `children=0` case [#148](https://github.com/plotly/dash-renderer/issues/148)
+
 ## [0.22.0] - 2019-04-10
 ### Added
 - Added support for clientside callbacks [#143](https://github.com/plotly/dash-renderer/pull/143)

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -33,7 +33,7 @@ const createContainer = component => isSimpleComponent(component) ?
 
 class TreeContainer extends Component {
     getChildren(components) {
-        if (!components) {
+        if (isNil(components)) {
             return null;
         }
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -104,7 +104,7 @@ class Tests(IntegrationTests):
 
         if expected_length is not None:
             self.assertEqual(len(request_queue), expected_length)
-    
+
     def test_initial_state(self):
         app = Dash(__name__)
         app.layout = html.Div([
@@ -472,6 +472,19 @@ class Tests(IntegrationTests):
         self.request_queue_assertions(0)
 
         self.percy_snapshot(name='layout')
+
+        assert_clean_console(self)
+
+    def test_nully_child(self):
+        app = Dash(__name__)
+        app.layout = html.Div(id='nully-wrapper', children=[0])
+
+        self.startServer(app)
+
+        self.wait_for_element_by_css_selector('#nully-wrapper')
+        wrapper = self.driver.find_element_by_id('nully-wrapper')
+
+        self.assertEqual(wrapper.get_attribute('innerHTML'), '0')
 
         assert_clean_console(self)
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -481,10 +481,7 @@ class Tests(IntegrationTests):
 
         self.startServer(app)
 
-        self.wait_for_element_by_css_selector('#nully-wrapper')
-        wrapper = self.driver.find_element_by_id('nully-wrapper')
-
-        self.assertEqual(wrapper.get_attribute('innerHTML'), '0')
+        self.wait_for_text_to_equal('#nully-wrapper', '0')
 
         assert_clean_console(self)
 
@@ -494,10 +491,7 @@ class Tests(IntegrationTests):
 
         self.startServer(app)
 
-        self.wait_for_element_by_css_selector('#nully-wrapper')
-        wrapper = self.driver.find_element_by_id('nully-wrapper')
-
-        self.assertEqual(wrapper.get_attribute('innerHTML'), '0')
+        self.wait_for_text_to_equal('#nully-wrapper', '0')
 
         assert_clean_console(self)
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -475,7 +475,7 @@ class Tests(IntegrationTests):
 
         assert_clean_console(self)
 
-    def test_array_of_nully_child(self):
+    def test_array_of_falsy_child(self):
         app = Dash(__name__)
         app.layout = html.Div(id='nully-wrapper', children=[0])
 
@@ -488,7 +488,7 @@ class Tests(IntegrationTests):
 
         assert_clean_console(self)
 
-    def test_of_nully_child(self):
+    def test_of_falsy_child(self):
         app = Dash(__name__)
         app.layout = html.Div(id='nully-wrapper', children=0)
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -475,9 +475,22 @@ class Tests(IntegrationTests):
 
         assert_clean_console(self)
 
-    def test_nully_child(self):
+    def test_array_of_nully_child(self):
         app = Dash(__name__)
         app.layout = html.Div(id='nully-wrapper', children=[0])
+
+        self.startServer(app)
+
+        self.wait_for_element_by_css_selector('#nully-wrapper')
+        wrapper = self.driver.find_element_by_id('nully-wrapper')
+
+        self.assertEqual(wrapper.get_attribute('innerHTML'), '0')
+
+        assert_clean_console(self)
+
+    def test_of_nully_child(self):
+        app = Dash(__name__)
+        app.layout = html.Div(id='nully-wrapper', children=0)
 
         self.startServer(app)
 


### PR DESCRIPTION
FIxes #148.

Found the issue in dash-docs percy deltas in https://percy.io/plotly/dash-docs/builds/1719186
![image](https://user-images.githubusercontent.com/8092993/55922940-61e1ef00-5bd1-11e9-9785-f1d778ddb493.png)

Add test for array case `children=[0]`, this passes with the existing code: https://github.com/plotly/dash-renderer/commit/0602a155e12ba718b1a9bc764b93e32c6bd78004

Add test for non-array case `children=0`, this fails with the existing code: https://github.com/plotly/dash-renderer/commit/d48e81dd2f52434a7fb86a707a8483e26e779078

Fix: https://github.com/plotly/dash-renderer/commit/b600b8cd296dd0ade14737dc6985e4596b10e736